### PR TITLE
add manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include *.rst
+recursive-include skprocrustes/ *.py
+recursive-include docs *


### PR DESCRIPTION
The manifest file ensures that everything listed there will be in the tarball.
The main difference from this PR and the current state is that this will include the `docs`, `README.rst`, `LICENSE.rst`, and `INSTALL.rst` in the source distribution tarball.

IMO they all should be there but in fact only the `LICENSE.rst` is really needed, so package managers can  satisfy the license demands to ship it with the code.